### PR TITLE
Fix tree view collapse behavior

### DIFF
--- a/src/renderer/components/TreeView.tsx
+++ b/src/renderer/components/TreeView.tsx
@@ -43,12 +43,24 @@ function TreeItem({ node, depth, selectedPath, onSelect }: TreeItemProps) {
   const isEntity = !!node.entity
   const isSelectable = isMarkdown || isPdf || isEntity
 
-  const handleClick = () => {
-    if (hasChildren) {
-      setExpanded(!expanded)
-    }
+  const handleChevronClick = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    setExpanded(!expanded)
+  }
+
+  const handleRowClick = () => {
     if (isSelectable) {
       onSelect(node)
+    }
+    if (hasChildren) {
+      if (isSelected) {
+        // Only toggle collapse if already viewing this item
+        setExpanded(!expanded)
+      } else if (!expanded) {
+        // Expand when navigating to a collapsed item
+        setExpanded(true)
+      }
+      // Don't collapse when navigating to an already-expanded item
     }
   }
 
@@ -79,10 +91,13 @@ function TreeItem({ node, depth, selectedPath, onSelect }: TreeItemProps) {
       <div
         className={`tree-item-row ${isSelected ? 'selected' : ''}`}
         style={{ paddingLeft: `${depth * INDENT_PX + BASE_PADDING_PX}px` }}
-        onClick={handleClick}
+        onClick={handleRowClick}
       >
         {hasChildren && (
-          <span className={`tree-chevron ${expanded ? 'expanded' : ''}`}>
+          <span
+            className={`tree-chevron ${expanded ? 'expanded' : ''}`}
+            onClick={handleChevronClick}
+          >
             ▶
           </span>
         )}


### PR DESCRIPTION
## Summary
- Chevron (▶) click now only toggles expand/collapse without navigating to the item
- Clicking an expanded parent while viewing another file no longer collapses it
- Clicking an already-selected item still toggles collapse as expected

## Test plan
- [ ] Click chevron on collapsed parent while viewing another file → expands without navigating
- [ ] Click chevron on expanded parent → collapses without navigating
- [ ] Click expanded parent row while viewing another file → navigates but stays expanded
- [ ] Click collapsed parent row → navigates and expands
- [ ] Click selected parent row → toggles collapse

🤖 Generated with [Claude Code](https://claude.com/claude-code)