### PR TITLE
Add markdown rendering to agent chat messages

### DIFF
--- a/src/renderer/components/AgentPanel.tsx
+++ b/src/renderer/components/AgentPanel.tsx
@@ -1,15 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
-import Markdown from 'react-markdown'
 import type { AgentMessage } from '@shared/types'
-import { REMARK_PLUGINS, REHYPE_PLUGINS } from '../markdownConfig'
-
-function AgentMarkdown({ content }: { content: string }) {
-  return (
-    <Markdown remarkPlugins={REMARK_PLUGINS} rehypePlugins={REHYPE_PLUGINS}>
-      {content}
-    </Markdown>
-  )
-}
+import { StyledMarkdown } from '../markdownConfig'
 
 interface AgentPanelProps {
   workingDir: string | null
@@ -145,7 +136,7 @@ export function AgentPanel({ workingDir, onClose }: AgentPanelProps) {
           <div key={i} className={`agent-message agent-message-${msg.role}`}>
             <div className="agent-message-content">
               {msg.role === 'assistant' ? (
-                <AgentMarkdown content={msg.content} />
+                <StyledMarkdown content={msg.content} />
               ) : (
                 msg.content
               )}
@@ -155,7 +146,7 @@ export function AgentPanel({ workingDir, onClose }: AgentPanelProps) {
         {streamingContent && (
           <div className="agent-message agent-message-assistant">
             <div className="agent-message-content">
-              <AgentMarkdown content={streamingContent} />
+              <StyledMarkdown content={streamingContent} />
             </div>
           </div>
         )}

--- a/src/renderer/components/MarkdownViewer.tsx
+++ b/src/renderer/components/MarkdownViewer.tsx
@@ -1,7 +1,5 @@
 import { useState, useEffect } from 'react'
-import Markdown from 'react-markdown'
-import 'katex/dist/katex.min.css'
-import { REMARK_PLUGINS, REHYPE_PLUGINS } from '../markdownConfig'
+import { StyledMarkdown } from '../markdownConfig'
 
 const MIN_ZOOM = 0.5
 const MAX_ZOOM = 2.0
@@ -35,12 +33,7 @@ export function MarkdownViewer({ content }: MarkdownViewerProps) {
 
   return (
     <div className="markdown-viewer" style={{ fontSize: `${zoom}em` }}>
-      <Markdown
-        remarkPlugins={REMARK_PLUGINS}
-        rehypePlugins={REHYPE_PLUGINS}
-      >
-        {content}
-      </Markdown>
+      <StyledMarkdown content={content} />
     </div>
   )
 }

--- a/src/renderer/markdownConfig.ts
+++ b/src/renderer/markdownConfig.ts
@@ -1,6 +1,0 @@
-import remarkGfm from 'remark-gfm'
-import remarkMath from 'remark-math'
-import rehypeKatex from 'rehype-katex'
-
-export const REMARK_PLUGINS = [remarkGfm, remarkMath]
-export const REHYPE_PLUGINS = [rehypeKatex]

--- a/src/renderer/markdownConfig.tsx
+++ b/src/renderer/markdownConfig.tsx
@@ -1,0 +1,20 @@
+import Markdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import remarkMath from 'remark-math'
+import rehypeKatex from 'rehype-katex'
+import 'katex/dist/katex.min.css'
+
+const REMARK_PLUGINS = [remarkGfm, remarkMath]
+const REHYPE_PLUGINS = [rehypeKatex]
+
+interface StyledMarkdownProps {
+  content: string
+}
+
+export function StyledMarkdown({ content }: StyledMarkdownProps) {
+  return (
+    <Markdown remarkPlugins={REMARK_PLUGINS} rehypePlugins={REHYPE_PLUGINS}>
+      {content}
+    </Markdown>
+  )
+}


### PR DESCRIPTION
## Summary
- Add markdown rendering (GFM + math) to agent chat assistant messages
- Use same react-markdown, remark-gfm, remark-math, and rehype-katex as MarkdownViewer
- Add CSS styling for markdown elements in chat bubbles
- User messages remain plain text with pre-wrap

## Test plan
- [ ] Open agent panel and send a message
- [ ] Verify code blocks, lists, headings render properly
- [ ] Verify LaTeX math expressions render ($inline$ and $$block$$)
- [ ] Verify streaming content also renders markdown