### PR TITLE
Fix #46 and #32: rename summarizePdf to summarize, cleanup session files

### DIFF
--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -34,7 +34,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.on('fs:changed', listener)
     return () => ipcRenderer.removeListener('fs:changed', listener)
   },
-  summarizePdf: (request: SummarizeRequest): Promise<SummarizeResult> =>
+  summarize: (request: SummarizeRequest): Promise<SummarizeResult> =>
     ipcRenderer.invoke('claude:summarize', request),
   agentChat: (request: AgentChatRequest): Promise<AgentChatResponse> =>
     ipcRenderer.invoke('agent:chat', request),

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -428,8 +428,8 @@ function App() {
     setShowSummarizeModal(false)
 
     try {
-      const result = await window.electronAPI.summarizePdf({
-        pdfPath: sourcePath,
+      const result = await window.electronAPI.summarize({
+        sourcePath,
         outputPath,
         prompt,
         workingDir: folderPath!,

--- a/src/shared/prompts.ts
+++ b/src/shared/prompts.ts
@@ -48,7 +48,7 @@ When you learn user info, append/update agent-memory.md.
 `
 
 export function getSummarizePrompt(
-  pdfPath: string,
+  sourcePath: string,
   outputPath: string,
   userPrompt: string,
   todosContext: string,
@@ -60,7 +60,7 @@ export function getSummarizePrompt(
     ? `\n\n## Existing Tracked Items${todoSection}${eventSection}`
     : ''
 
-  return `Read the file at "${pdfPath}". THIS IS A [T1] TASK. Create a markdown summary at "${outputPath}" with the following:
+  return `Read the file at "${sourcePath}". THIS IS A [T1] TASK. Create a markdown summary at "${outputPath}" with the following:
 
 ${userPrompt}${contextSection}`
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -49,7 +49,7 @@ export function isStructureChange(eventType: FileChangeEventType): boolean {
 }
 
 export interface SummarizeRequest {
-  pdfPath: string
+  sourcePath: string
   outputPath: string
   prompt: string
   workingDir: string
@@ -126,7 +126,7 @@ export interface ElectronAPI {
   move: (sourcePath: string, destPath: string) => Promise<{ success: boolean; error?: string }>
   deleteFile: (filePath: string) => Promise<{ success: boolean; error?: string }>
   onFileChange: (callback: (event: FileChangeEvent) => void) => () => void
-  summarizePdf: (request: SummarizeRequest) => Promise<SummarizeResult>
+  summarize: (request: SummarizeRequest) => Promise<SummarizeResult>
   agentChat: (request: AgentChatRequest) => Promise<AgentChatResponse>
   agentCancel: () => Promise<void>
   onAgentComplete: (callback: (error?: string) => void) => () => void


### PR DESCRIPTION
## Summary
- Renames `summarizePdf` API to `summarize` and `pdfPath` to `sourcePath` (fixes #46)
- Cleans up Claude CLI session files after summarization completes, preserving chat sessions and agent-* files (fixes #32)

## Test plan
- [ ] Run summarization on a PDF or markdown file
- [ ] Verify the output file is created correctly
- [ ] Check `~/.claude/projects/[encoded-path]/` - new JSONL files from summarization should be deleted
- [ ] Verify existing chat sessions are preserved