### PR TITLE
Fix entity rename to preserve original file extensions

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -711,7 +711,7 @@ function App() {
         const member = renameTarget.member
         const entity = selectedNode.entity
         const dir = getDirname(member.path)
-        const ext = member.type === 'pdf' ? '.pdf' : '.md'
+        const ext = getExtension(member.path)
         const newFileName = newName ? `${entity.baseName}.${newName}${ext}` : `${entity.baseName}${ext}`
         const newPath = `${dir}/${newFileName}`
 


### PR DESCRIPTION
## Summary
- Uses `getExtension(member.path)` instead of hardcoded extension logic
- Fixes video/audio members being incorrectly renamed with `.md` extension

Closes #113