### PR TITLE
Open external links in default browser

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -330,6 +330,12 @@ ipcMain.handle('shell:openInExplorer', async (_event, filePath: string) => {
   shell.showItemInFolder(filePath)
 })
 
+ipcMain.handle('shell:openExternal', async (_event, url: string) => {
+  if (url.startsWith('http://') || url.startsWith('https://')) {
+    await shell.openExternal(url)
+  }
+})
+
 ipcMain.handle('fs:mkdir', async (_event, dirPath: string) => {
   try {
     await fs.promises.mkdir(dirPath, { recursive: true })

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -27,6 +27,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   unwatchFolder: (): Promise<void> => ipcRenderer.invoke('fs:unwatchFolder'),
   openInExplorer: (folderPath: string): Promise<void> =>
     ipcRenderer.invoke('shell:openInExplorer', folderPath),
+  openExternal: (url: string): Promise<void> =>
+    ipcRenderer.invoke('shell:openExternal', url),
   mkdir: (dirPath: string): Promise<{ success: boolean; error?: string }> =>
     ipcRenderer.invoke('fs:mkdir', dirPath),
   move: (sourcePath: string, destPath: string): Promise<{ success: boolean; error?: string }> =>

--- a/src/renderer/markdownConfig.tsx
+++ b/src/renderer/markdownConfig.tsx
@@ -1,4 +1,4 @@
-import Markdown from 'react-markdown'
+import Markdown, { Components } from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import remarkMath from 'remark-math'
 import rehypeRaw from 'rehype-raw'
@@ -29,12 +29,33 @@ function allowLocalImageProtocol(url: string): string {
   return ''
 }
 
+// Custom link component that opens external URLs in the default browser
+const ExternalLink: Components['a'] = ({ href, children, ...props }) => {
+  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    if (href && (href.startsWith('http://') || href.startsWith('https://'))) {
+      e.preventDefault()
+      window.electronAPI.openExternal(href)
+    }
+  }
+
+  return (
+    <a href={href} onClick={handleClick} {...props}>
+      {children}
+    </a>
+  )
+}
+
+const MARKDOWN_COMPONENTS: Components = {
+  a: ExternalLink,
+}
+
 export function StyledMarkdown({ content }: StyledMarkdownProps) {
   return (
     <Markdown
       remarkPlugins={REMARK_PLUGINS}
       rehypePlugins={REHYPE_PLUGINS}
       urlTransform={allowLocalImageProtocol}
+      components={MARKDOWN_COMPONENTS}
     >
       {content}
     </Markdown>

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -180,6 +180,7 @@ export interface ElectronAPI {
   watchFolder: (folderPath: string) => Promise<void>
   unwatchFolder: () => Promise<void>
   openInExplorer: (folderPath: string) => Promise<void>
+  openExternal: (url: string) => Promise<void>
   mkdir: (dirPath: string) => Promise<{ success: boolean; error?: string }>
   move: (sourcePath: string, destPath: string) => Promise<{ success: boolean; error?: string }>
   deleteFile: (filePath: string) => Promise<{ success: boolean; error?: string }>


### PR DESCRIPTION
## Summary
- External links (http/https) in markdown now open in the user's default browser instead of within the Electron app
- Added `shell:openExternal` IPC handler and exposed it to the renderer
- Custom link component intercepts clicks and uses `shell.openExternal()` for external URLs

Closes #121