### PR TITLE
Remember markdown scroll position when switching tabs/entities

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -475,9 +475,7 @@ function App() {
     if (!container || !activeFilePath) return
 
     const handleScroll = () => {
-      if (activeFilePath) {
-        scrollPositions.set(activeFilePath, container.scrollTop)
-      }
+      scrollPositions.set(activeFilePath, container.scrollTop)
     }
 
     container.addEventListener('scroll', handleScroll)


### PR DESCRIPTION
## Summary
- Persists scroll positions for markdown content across tab/entity switches within the session
- Uses a Map to store scroll positions by file path (same pattern as PdfViewer)
- Restores scroll position after content loads

Closes #99

## Test plan
- [ ] Open a long markdown file and scroll to the middle
- [ ] Switch to another tab/file
- [ ] Switch back - scroll position should be restored
- [ ] Verify works for both entity members and standalone files