### PR TITLE
Add archive system with toggle to hide/show archived items

### DIFF
--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -23,6 +23,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
   getExpandedPaths: (): Promise<string[]> => ipcRenderer.invoke('settings:getExpandedPaths'),
   setExpandedPaths: (paths: string[]): Promise<void> =>
     ipcRenderer.invoke('settings:setExpandedPaths', paths),
+  getArchivedPaths: (folderPath: string): Promise<string[]> =>
+    ipcRenderer.invoke('archive:getArchivedPaths', folderPath),
+  setArchivedPaths: (folderPath: string, paths: string[]): Promise<void> =>
+    ipcRenderer.invoke('archive:setArchivedPaths', folderPath, paths),
   setWindowTitle: (title: string): Promise<void> =>
     ipcRenderer.invoke('window:setTitle', title),
   watchFolder: (folderPath: string): Promise<void> =>

--- a/src/renderer/components/SidebarToolbar.tsx
+++ b/src/renderer/components/SidebarToolbar.tsx
@@ -1,12 +1,20 @@
-import { Plus, Folder, Settings } from 'lucide-react'
+import { Plus, Folder, Settings, Archive } from 'lucide-react'
 
 interface SidebarToolbarProps {
   onNewNote: () => void
   onOpenFolder: () => void
   onOpenOptions: () => void
+  showArchived: boolean
+  onToggleArchived: () => void
 }
 
-export function SidebarToolbar({ onNewNote, onOpenFolder, onOpenOptions }: SidebarToolbarProps) {
+export function SidebarToolbar({
+  onNewNote,
+  onOpenFolder,
+  onOpenOptions,
+  showArchived,
+  onToggleArchived,
+}: SidebarToolbarProps) {
   return (
     <div className="sidebar-toolbar">
       <button
@@ -22,6 +30,13 @@ export function SidebarToolbar({ onNewNote, onOpenFolder, onOpenOptions }: Sideb
         title="Open in File Explorer"
       >
         <Folder size={18} strokeWidth={1.5} />
+      </button>
+      <button
+        className={`sidebar-toolbar-btn ${showArchived ? 'active' : ''}`}
+        onClick={onToggleArchived}
+        title={showArchived ? 'Hide Archived Items' : 'Show Archived Items'}
+      >
+        <Archive size={18} strokeWidth={1.5} />
       </button>
       <button
         className="sidebar-toolbar-btn"

--- a/src/renderer/components/TreeView.tsx
+++ b/src/renderer/components/TreeView.tsx
@@ -219,6 +219,7 @@ function TreeItem({ node, depth, selectedPath, expandedPaths, onSelect, onToggle
     isSuggestion && 'suggestion',
     isBeingDragged && 'dragging',
     isDropTarget && 'drop-target',
+    node.isArchived && 'archived',
   ].filter(Boolean).join(' ')
 
   return (

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -297,6 +297,15 @@ body {
   color: #d4d4d4;
 }
 
+.sidebar-toolbar-btn.active {
+  background-color: #0e639c;
+  color: #ffffff;
+}
+
+.sidebar-toolbar-btn.active:hover {
+  background-color: #1177bb;
+}
+
 .content {
   flex: 1;
   display: flex;
@@ -389,6 +398,23 @@ body {
   background-color: rgba(14, 99, 156, 0.4);
   outline: 2px solid #0e639c;
   outline-offset: -2px;
+}
+
+/* Archived items - muted appearance */
+.tree-item-row.archived {
+  opacity: 0.5;
+}
+
+.tree-item-row.archived .tree-name {
+  font-style: italic;
+}
+
+.tree-item-row.archived:hover {
+  opacity: 0.7;
+}
+
+.tree-item-row.archived.selected {
+  opacity: 0.8;
 }
 
 .tree-chevron {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -95,6 +95,7 @@ export interface TreeNode {
   entity?: Entity // if this node represents an entity (grouped files)
   children?: TreeNode[]
   isSuggestion?: 'todos' | 'events' // if this is a suggestion draft file
+  isArchived?: boolean // if this node is archived (hidden from view unless toggle is on)
 }
 
 export type FileChangeEventType = 'add' | 'addDir' | 'change' | 'unlink' | 'unlinkDir'
@@ -202,6 +203,8 @@ export interface ElectronAPI {
   setShowClaudeMd: (show: boolean) => Promise<void>
   getExpandedPaths: () => Promise<string[]>
   setExpandedPaths: (paths: string[]) => Promise<void>
+  getArchivedPaths: (folderPath: string) => Promise<string[]>
+  setArchivedPaths: (folderPath: string, paths: string[]) => Promise<void>
   setWindowTitle: (title: string) => Promise<void>
   watchFolder: (folderPath: string) => Promise<void>
   unwatchFolder: () => Promise<void>


### PR DESCRIPTION
## Summary
- Adds archive functionality to hide old content from the sidebar
- Archive/Unarchive via right-click context menu on any file or folder
- Toggle button in sidebar toolbar to show/hide archived items
- Archived paths stored in `.markerdown/archive.json` per workspace
- Archived items appear faded/italic when visible

## Test plan
- [ ] Right-click a file → Archive → file disappears from sidebar
- [ ] Click Archive toggle button in sidebar toolbar → archived items appear (faded)
- [ ] Right-click archived item → Unarchive → item returns to normal
- [ ] Close and reopen app → archived state persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)