### PR TITLE
Add undo/redo buttons to markdown editor toolbar

### DIFF
--- a/src/renderer/components/CodeMirrorEditor.tsx
+++ b/src/renderer/components/CodeMirrorEditor.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useCallback, forwardRef, useImperativeHandle } from 'react'
 import { EditorState } from '@codemirror/state'
 import { EditorView, lineNumbers, highlightActiveLine, keymap } from '@codemirror/view'
-import { defaultKeymap, history, historyKeymap } from '@codemirror/commands'
+import { defaultKeymap, history, historyKeymap, undo, redo } from '@codemirror/commands'
 import { markdown } from '@codemirror/lang-markdown'
 import { oneDark } from '@codemirror/theme-one-dark'
 import { ActiveFormats, defaultFormats } from './editorTypes'
@@ -26,6 +26,8 @@ export interface CodeMirrorEditorRef {
   insertCodeBlock: () => void
   insertTable: () => void
   getActiveFormats: () => ActiveFormats
+  undo: () => void
+  redo: () => void
 }
 
 interface CodeMirrorEditorProps {
@@ -194,6 +196,14 @@ export const CodeMirrorEditor = forwardRef<CodeMirrorEditorRef, CodeMirrorEditor
       insertCodeBlock: () => insertAtCursor('\n```\n\n```\n'),
       insertTable: () => insertAtCursor('\n| Column 1 | Column 2 | Column 3 |\n|----------|----------|----------|\n| Cell 1   | Cell 2   | Cell 3   |\n'),
       getActiveFormats,
+      undo: () => {
+        const view = viewRef.current
+        if (view) undo(view)
+      },
+      redo: () => {
+        const view = viewRef.current
+        if (view) redo(view)
+      },
     }))
 
     const handleChange = useCallback((update: { docChanged: boolean; selectionSet: boolean; state: EditorState }) => {

--- a/src/renderer/components/FormatToolbar.tsx
+++ b/src/renderer/components/FormatToolbar.tsx
@@ -11,6 +11,9 @@ export function FormatToolbar({
 }: FormatToolbarProps) {
   return (
     <div className="editor-format-toolbar" onMouseDown={(e) => e.preventDefault()}>
+      <button onClick={() => editorRef.current?.undo()} title="Undo (Ctrl+Z)">↶</button>
+      <button onClick={() => editorRef.current?.redo()} title="Redo (Ctrl+Y)">↷</button>
+      <span className="toolbar-divider" />
       <button className={activeFormats.bold ? 'active' : ''} onClick={() => editorRef.current?.bold()} title="Bold (Ctrl+B)">B</button>
       <button className={activeFormats.italic ? 'active' : ''} onClick={() => editorRef.current?.italic()} title="Italic (Ctrl+I)"><em>I</em></button>
       <button className={activeFormats.strikethrough ? 'active' : ''} onClick={() => editorRef.current?.strikethrough()} title="Strikethrough"><s>S</s></button>

--- a/src/renderer/components/MarkdownEditor.tsx
+++ b/src/renderer/components/MarkdownEditor.tsx
@@ -24,6 +24,8 @@ export interface MarkdownEditorRef {
   insertCodeBlock: () => void
   insertTable: () => void
   getActiveFormats: () => ActiveFormats
+  undo: () => void
+  redo: () => void
 }
 
 interface MarkdownEditorProps {
@@ -119,6 +121,14 @@ export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>
         else if (mode === 'code') codemirrorRef.current?.insertTable()
       },
       getActiveFormats,
+      undo: () => {
+        if (mode === 'visual') milkdownRef.current?.undo()
+        else if (mode === 'code') codemirrorRef.current?.undo()
+      },
+      redo: () => {
+        if (mode === 'visual') milkdownRef.current?.redo()
+        else if (mode === 'code') codemirrorRef.current?.redo()
+      },
     }))
 
     // Track content changes

--- a/src/renderer/components/MilkdownEditor.tsx
+++ b/src/renderer/components/MilkdownEditor.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, forwardRef, useImperativeHandle, useCallback } from 
 import { Editor, rootCtx, defaultValueCtx, editorViewOptionsCtx, editorViewCtx } from '@milkdown/core'
 import { commonmark, toggleStrongCommand, toggleEmphasisCommand, wrapInHeadingCommand, wrapInBulletListCommand, wrapInOrderedListCommand, wrapInBlockquoteCommand, insertHrCommand, insertImageCommand, toggleInlineCodeCommand } from '@milkdown/preset-commonmark'
 import { gfm, toggleStrikethroughCommand, insertTableCommand } from '@milkdown/preset-gfm'
-import { history } from '@milkdown/plugin-history'
+import { history, undoCommand, redoCommand } from '@milkdown/plugin-history'
 import { clipboard } from '@milkdown/plugin-clipboard'
 import { listener, listenerCtx } from '@milkdown/plugin-listener'
 import { callCommand } from '@milkdown/utils'
@@ -30,6 +30,8 @@ export interface MilkdownEditorRef {
   insertLink: (href: string, text?: string) => void
   insertCode: () => void
   insertCodeBlock: () => void
+  undo: () => void
+  redo: () => void
 }
 
 interface MilkdownEditorProps {
@@ -156,6 +158,12 @@ export const MilkdownEditor = forwardRef<MilkdownEditorRef, MilkdownEditorProps>
       insertCodeBlock: () => {
         // TODO: Milkdown requires more complex prosemirror integration for code blocks
         // Use code mode for explicit code block insertion
+      },
+      undo: () => {
+        editorRef.current?.action(callCommand(undoCommand.key))
+      },
+      redo: () => {
+        editorRef.current?.action(callCommand(redoCommand.key))
       },
     }))
 


### PR DESCRIPTION
## Summary
- Added undo/redo buttons (↶/↷) at the start of the format toolbar
- Exposed undo/redo methods through editor refs (MilkdownEditor, CodeMirrorEditor, MarkdownEditor)
- Works in both visual (WYSIWYG) and code editing modes

## Test plan
- [ ] Open a markdown file in visual mode, make changes, click undo/redo buttons
- [ ] Switch to code mode, make changes, verify undo/redo buttons work
- [ ] Verify Ctrl+Z and Ctrl+Y keyboard shortcuts still work