### PR TITLE
Move entity tabs to slim bottom bar (#90)

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -11,6 +11,7 @@ import { TodoPanel } from './components/TodoPanel'
 import { EventPanel } from './components/EventPanel'
 import { OptionsModal } from './components/OptionsModal'
 import { TopToolbar, PaneType } from './components/TopToolbar'
+import { BottomTabBar } from './components/BottomTabBar'
 import { SidebarToolbar } from './components/SidebarToolbar'
 import { ContextMenu, ContextMenuItem } from './components/ContextMenu'
 import { DeleteConfirmModal } from './components/DeleteConfirmModal'
@@ -1755,12 +1756,6 @@ function App() {
         )}
         <section className="content">
           <TopToolbar
-            entity={selectedNode?.entity}
-            activeMember={activeMember ?? undefined}
-            onTabChange={handleTabChange}
-            selectedFileName={selectedFileName}
-            selectedFileType={selectedFileType}
-            onTabContextMenu={handleTabContextMenu}
             editMode={editMode}
             onEditModeChange={setEditMode}
             editorRef={editorRef}
@@ -1777,7 +1772,6 @@ function App() {
             onDiscardSuggestion={handleDiscardSuggestion}
             sidebarVisible={sidebarVisible}
             onSidebarToggle={() => setSidebarVisible((v) => !v)}
-            onCreateMember={handleCreateMember}
           />
           <div className="content-body-wrapper">
             <div className="content-body" ref={contentBodyRef}>
@@ -1829,6 +1823,15 @@ function App() {
               />
             </aside>
           </div>
+          <BottomTabBar
+            entity={selectedNode?.entity}
+            activeMember={activeMember ?? undefined}
+            onTabChange={handleTabChange}
+            selectedFileName={selectedFileName}
+            selectedFileType={selectedFileType}
+            onTabContextMenu={handleTabContextMenu}
+            onCreateMember={handleCreateMember}
+          />
         </section>
       </main>
       <SummarizeModal

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -671,6 +671,8 @@ function App() {
   }
 
   const handleTabChange = (member: EntityMember) => {
+    setEditContent(null)
+    setIsDirty(false)
     setActiveMember(member)
   }
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -671,7 +671,6 @@ function App() {
   }
 
   const handleTabChange = (member: EntityMember) => {
-    resetEditState()
     setActiveMember(member)
   }
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -672,6 +672,7 @@ function App() {
 
   const handleTabChange = (member: EntityMember) => {
     setEditContent(null)
+    setFileContent(null)
     setIsDirty(false)
     setActiveMember(member)
   }

--- a/src/renderer/components/BottomTabBar.tsx
+++ b/src/renderer/components/BottomTabBar.tsx
@@ -1,0 +1,131 @@
+import type { Entity, EntityMember } from '@shared/types'
+import { Plus } from 'lucide-react'
+
+/**
+ * Simple string hash function (djb2 algorithm)
+ */
+function hashString(str: string): number {
+  let hash = 5381
+  for (let i = 0; i < str.length; i++) {
+    hash = (hash * 33) ^ str.charCodeAt(i)
+  }
+  return hash >>> 0
+}
+
+function stringToColors(str: string): { base: string; light: string } {
+  const hash = hashString(str)
+  const hue = hash % 360
+  return {
+    base: `hsl(${hue}, 65%, 40%)`,
+    light: `hsl(${hue}, 65%, 60%)`,
+  }
+}
+
+interface BottomTabBarProps {
+  entity?: Entity
+  activeMember?: EntityMember
+  onTabChange?: (member: EntityMember) => void
+  selectedFileName?: string
+  selectedFileType?: string
+  onTabContextMenu?: (e: React.MouseEvent, member: EntityMember) => void
+  onCreateMember?: () => void
+}
+
+export function BottomTabBar({
+  entity,
+  activeMember,
+  onTabChange,
+  selectedFileName,
+  selectedFileType,
+  onTabContextMenu,
+  onCreateMember,
+}: BottomTabBarProps) {
+  const getTabLabel = (member: EntityMember) => {
+    if (member.type === 'pdf') {
+      return member.variant ? `${member.variant} (PDF)` : 'PDF'
+    }
+    if (member.type === 'image') {
+      return member.variant ? `${member.variant} (Image)` : 'Image'
+    }
+    if (member.variant === null && entity) {
+      return entity.baseName
+    }
+    return member.variant
+  }
+
+  const getTabColors = (member: EntityMember) => {
+    const label = getTabLabel(member) || ''
+    return stringToColors(label)
+  }
+
+  const hasTabs =
+    (entity && activeMember && onTabChange) || selectedFileName
+
+  if (!hasTabs) return null
+
+  return (
+    <div className="bottom-tab-bar">
+      {entity && activeMember && onTabChange ? (
+        <>
+          {entity.members.map((member) => {
+            const isActive = member.path === activeMember.path
+            const colors = getTabColors(member)
+            return (
+              <button
+                key={member.path}
+                type="button"
+                className={`entity-tab ${isActive ? 'active' : ''}`}
+                style={{
+                  backgroundColor: colors.base,
+                  borderColor: isActive ? colors.light : colors.base,
+                  fontWeight: isActive ? 'bold' : 'normal',
+                }}
+                onClick={() => onTabChange(member)}
+                onContextMenu={(e) => {
+                  e.preventDefault()
+                  onTabContextMenu?.(e, member)
+                }}
+              >
+                {getTabLabel(member)}
+              </button>
+            )
+          })}
+          {onCreateMember && (
+            <button
+              type="button"
+              className="entity-tab-add"
+              onClick={onCreateMember}
+              title="Add new variant"
+            >
+              <Plus size={14} />
+            </button>
+          )}
+        </>
+      ) : selectedFileName ? (
+        <>
+          <button
+            type="button"
+            className="entity-tab active"
+            style={{
+              backgroundColor: stringToColors(selectedFileName).base,
+              borderColor: stringToColors(selectedFileName).light,
+              fontWeight: 'bold',
+            }}
+          >
+            {selectedFileType === 'markdown' ? selectedFileName : selectedFileType?.toUpperCase()}
+          </button>
+          {onCreateMember && selectedFileType === 'markdown' && (
+            <button
+              type="button"
+              className="entity-tab-add"
+              onClick={onCreateMember}
+              title="Add new variant"
+            >
+              <Plus size={14} />
+            </button>
+          )}
+        </>
+      ) : null}
+    </div>
+  )
+}

--- a/src/renderer/components/BottomTabBar.tsx
+++ b/src/renderer/components/BottomTabBar.tsx
@@ -63,6 +63,8 @@ export function BottomTabBar({
 
   if (!hasTabs) return null
 
+  const standaloneColors = selectedFileName ? stringToColors(selectedFileName) : null
+
   return (
     <div className="bottom-tab-bar">
       {entity && activeMember && onTabChange ? (
@@ -101,14 +103,14 @@ export function BottomTabBar({
             </button>
           )}
         </>
-      ) : selectedFileName ? (
+      ) : selectedFileName && standaloneColors ? (
         <>
           <button
             type="button"
             className="entity-tab active"
             style={{
-              backgroundColor: stringToColors(selectedFileName).base,
-              borderColor: stringToColors(selectedFileName).light,
+              backgroundColor: standaloneColors.base,
+              borderColor: standaloneColors.light,
               fontWeight: 'bold',
             }}
           >

--- a/src/renderer/components/MarkdownEditor.tsx
+++ b/src/renderer/components/MarkdownEditor.tsx
@@ -46,12 +46,6 @@ export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>
     const milkdownRef = useRef<MilkdownEditorRef>(null)
     const codemirrorRef = useRef<CodeMirrorEditorRef>(null)
     const currentContentRef = useRef(content)
-    const prevFilePathRef = useRef(filePath)
-    // Sync ref when file changes (tab switch), not during active editing
-    if (filePath !== prevFilePathRef.current) {
-      currentContentRef.current = content
-      prevFilePathRef.current = filePath
-    }
 
     // Helper to get active formats from current editor
     const getActiveFormats = useCallback((): ActiveFormats => {

--- a/src/renderer/components/MarkdownEditor.tsx
+++ b/src/renderer/components/MarkdownEditor.tsx
@@ -46,6 +46,12 @@ export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>
     const milkdownRef = useRef<MilkdownEditorRef>(null)
     const codemirrorRef = useRef<CodeMirrorEditorRef>(null)
     const currentContentRef = useRef(content)
+    const prevFilePathRef = useRef(filePath)
+    // Sync ref when file changes (tab switch), not during active editing
+    if (filePath !== prevFilePathRef.current) {
+      currentContentRef.current = content
+      prevFilePathRef.current = filePath
+    }
 
     // Helper to get active formats from current editor
     const getActiveFormats = useCallback((): ActiveFormats => {
@@ -175,6 +181,7 @@ export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>
 
           {mode === 'code' && (
             <CodeMirrorEditor
+              key={filePath}
               ref={codemirrorRef}
               content={currentContentRef.current}
               filePath={filePath}

--- a/src/renderer/components/TopToolbar.tsx
+++ b/src/renderer/components/TopToolbar.tsx
@@ -1,40 +1,12 @@
-import type { Entity, EntityMember, EditMode } from '@shared/types'
+import type { EditMode } from '@shared/types'
 import type { ActiveFormats, MarkdownEditorRef } from './MarkdownEditor'
 import { FormatToolbar } from './FormatToolbar'
 import { ModeToggle } from './ModeToggle'
-import { MessageSquare, CheckSquare, Calendar, Check, X, Sparkles, PanelLeft, Plus } from 'lucide-react'
+import { MessageSquare, CheckSquare, Calendar, Check, X, Sparkles, PanelLeft } from 'lucide-react'
 
 export type PaneType = 'agent' | 'todos' | 'events'
 
-/**
- * Simple string hash function (djb2 algorithm)
- */
-function hashString(str: string): number {
-  let hash = 5381
-  for (let i = 0; i < str.length; i++) {
-    hash = (hash * 33) ^ str.charCodeAt(i)
-  }
-  return hash >>> 0
-}
-
-function stringToColors(str: string): { base: string; light: string } {
-  const hash = hashString(str)
-  const hue = hash % 360
-  return {
-    base: `hsl(${hue}, 65%, 40%)`,
-    light: `hsl(${hue}, 65%, 60%)`,
-  }
-}
-
 interface TopToolbarProps {
-  // Entity tab props (optional - only when viewing entity)
-  entity?: Entity
-  activeMember?: EntityMember
-  onTabChange?: (member: EntityMember) => void
-  // Standalone file props (for showing single tab)
-  selectedFileName?: string
-  selectedFileType?: string
-  onTabContextMenu?: (e: React.MouseEvent, member: EntityMember) => void
   // Editor props
   editMode: EditMode
   onEditModeChange: (mode: EditMode) => void
@@ -57,17 +29,9 @@ interface TopToolbarProps {
   // Sidebar toggle props
   sidebarVisible: boolean
   onSidebarToggle: () => void
-  // Create new entity member
-  onCreateMember?: () => void
 }
 
 export function TopToolbar({
-  entity,
-  activeMember,
-  onTabChange,
-  selectedFileName,
-  selectedFileType,
-  onTabContextMenu,
   editMode,
   onEditModeChange,
   editorRef,
@@ -84,26 +48,7 @@ export function TopToolbar({
   onDiscardSuggestion,
   sidebarVisible,
   onSidebarToggle,
-  onCreateMember,
 }: TopToolbarProps) {
-  const getTabLabel = (member: EntityMember) => {
-    if (member.type === 'pdf') {
-      return member.variant ? `${member.variant} (PDF)` : 'PDF'
-    }
-    if (member.type === 'image') {
-      return member.variant ? `${member.variant} (Image)` : 'Image'
-    }
-    if (member.variant === null && entity) {
-      return entity.baseName
-    }
-    return member.variant
-  }
-
-  const getTabColors = (member: EntityMember) => {
-    const label = getTabLabel(member) || ''
-    return stringToColors(label)
-  }
-
   return (
     <div className="top-toolbar">
       {/* Sidebar toggle */}
@@ -115,75 +60,6 @@ export function TopToolbar({
         <PanelLeft size={16} strokeWidth={1.5} />
       </button>
       <div className="toolbar-separator" />
-
-      {/* Show tabs for entity or standalone file */}
-      {!isEditing && (
-        <>
-          {entity && activeMember && onTabChange ? (
-            // Entity with multiple members
-            <>
-              {entity.members.map((member) => {
-                const isActive = member.path === activeMember.path
-                const colors = getTabColors(member)
-                return (
-                  <button
-                    key={member.path}
-                    type="button"
-                    className={`entity-tab ${isActive ? 'active' : ''}`}
-                    style={{
-                      backgroundColor: colors.base,
-                      borderColor: isActive ? colors.light : colors.base,
-                      fontWeight: isActive ? 'bold' : 'normal',
-                    }}
-                    onClick={() => onTabChange(member)}
-                    onContextMenu={(e) => {
-                      e.preventDefault()
-                      onTabContextMenu?.(e, member)
-                    }}
-                  >
-                    {getTabLabel(member)}
-                  </button>
-                )
-              })}
-              {onCreateMember && (
-                <button
-                  type="button"
-                  className="entity-tab-add"
-                  onClick={onCreateMember}
-                  title="Add new variant"
-                >
-                  <Plus size={14} />
-                </button>
-              )}
-            </>
-          ) : selectedFileName ? (
-            // Standalone file - show single tab
-            <>
-              <button
-                type="button"
-                className="entity-tab active"
-                style={{
-                  backgroundColor: stringToColors(selectedFileName).base,
-                  borderColor: stringToColors(selectedFileName).light,
-                  fontWeight: 'bold',
-                }}
-              >
-                {selectedFileType === 'markdown' ? selectedFileName : selectedFileType?.toUpperCase()}
-              </button>
-              {onCreateMember && selectedFileType === 'markdown' && (
-                <button
-                  type="button"
-                  className="entity-tab-add"
-                  onClick={onCreateMember}
-                  title="Add new variant"
-                >
-                  <Plus size={14} />
-                </button>
-              )}
-            </>
-          ) : null}
-        </>
-      )}
 
       {/* Show formatting toolbar in edit mode */}
       {isEditing && (

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -488,6 +488,16 @@ body {
   border-color: rgba(128, 128, 128, 0.5);
 }
 
+/* Bottom Tab Bar - always visible below content */
+.bottom-tab-bar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-top: 1px solid #3c3c3c;
+  flex-shrink: 0;
+}
+
 .tab-action-btn {
   display: flex;
   align-items: center;

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -496,6 +496,7 @@ body {
   padding: 4px 12px;
   border-top: 1px solid #3c3c3c;
   flex-shrink: 0;
+  height: 41px;
 }
 
 .bottom-tab-bar .entity-tab {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -493,9 +493,18 @@ body {
   display: flex;
   align-items: center;
   gap: 6px;
-  padding: 6px 12px;
+  padding: 4px 12px;
   border-top: 1px solid #3c3c3c;
   flex-shrink: 0;
+}
+
+.bottom-tab-bar .entity-tab {
+  padding: 3px 10px;
+}
+
+.bottom-tab-bar .entity-tab-add {
+  width: 26px;
+  height: 26px;
 }
 
 .tab-action-btn {


### PR DESCRIPTION
## Summary
- Extracted tab rendering (entity tabs, standalone file tab, + variant button) from `TopToolbar` into a new `BottomTabBar` component
- Placed `BottomTabBar` at the bottom of the content section, always visible — including during edit mode (previously hidden)
- Decluttered `TopToolbar` by removing all tab-related props and code

Closes #90

## Test plan
- [ ] Open an entity with multiple members → tabs appear at bottom, switching works
- [ ] Open a standalone file → single tab at bottom
- [ ] Enter edit mode → tabs remain visible at bottom
- [ ] Right-click a tab → context menu works
- [ ] Click + button → new member modal opens
- [ ] TopToolbar is visibly less cluttered